### PR TITLE
Advanced attribute manager

### DIFF
--- a/backtracepython/attributes/attribute_manager.py
+++ b/backtracepython/attributes/attribute_manager.py
@@ -1,51 +1,44 @@
 import platform
 
-from backtracepython.attributes.backtrace_attribute_provider import (
-    BacktraceAttributeProvider,
-)
-from backtracepython.attributes.linux_memory_attribute_provider import (
-    LinuxMemoryAttributeProvider,
-)
-from backtracepython.attributes.machine_attribute_provider import (
-    MachineAttributeProvider,
-)
-from backtracepython.attributes.machineId_attribute_provider import (
-    MachineIdAttributeProvider,
-)
-from backtracepython.attributes.process_attribute_provider import (
-    ProcessAttributeProvider,
-)
-from backtracepython.attributes.session_attribute_provider import (
-    SessionAttributeProvider,
-)
-from backtracepython.attributes.system_attribute_provider import SystemAttributeProvider
+from .backtrace_attribute_provider import BacktraceAttributeProvider
+from .linux_memory_attribute_provider import LinuxMemoryAttributeProvider
+from .machine_attribute_provider import MachineAttributeProvider
+from .machineId_attribute_provider import MachineIdAttributeProvider
+from .process_attribute_provider import ProcessAttributeProvider
+from .report_data_builder import ReportDataBuilder
+from .session_attribute_provider import SessionAttributeProvider
+from .system_attribute_provider import SystemAttributeProvider
+from .user_attribute_provider import UserAttributeProvider
 
 
 class AttributeManager:
     def __init__(self):
-        self.dynamic_attributes = self.get_predefined_dynamic_attribute_providers()
-        self.scoped_attributes = {}
-        for (
-            scoped_attribute_provider
-        ) in self.get_predefined_scoped_attribute_providers():
-            self.try_add(self.scoped_attributes, scoped_attribute_provider)
+        self.attribute_providers = (
+            self.get_predefined_dynamic_attribute_providers()
+            + self.get_predefined_scoped_attribute_providers()
+        )
 
     def get(self):
-        result = {}
-        for dynamic_attribute_provider in self.dynamic_attributes:
-            self.try_add(result, dynamic_attribute_provider)
-        result.update(self.scoped_attributes)
+        attributes = {}
+        annotations = {}
+        for attribute_provider in self.attribute_providers:
 
-        return result
+            generated_attributes, generated_annotations = ReportDataBuilder.get(
+                self.try_get(attribute_provider)
+            )
+            attributes.update(generated_attributes)
+            annotations.update(generated_annotations)
+
+        return attributes, annotations
 
     def add(self, attributes):
-        self.scoped_attributes.update(attributes)
+        self.attribute_providers.append(UserAttributeProvider(attributes))
 
-    def try_add(self, dictionary, provider):
+    def try_get(self, provider):
         try:
-            dictionary.update(provider.get())
+            return provider.get()
         except:
-            return
+            return {}
 
     def get_predefined_scoped_attribute_providers(self):
         return [

--- a/backtracepython/attributes/report_data_builder.py
+++ b/backtracepython/attributes/report_data_builder.py
@@ -1,0 +1,20 @@
+import unicodedata
+
+
+class ReportDataBuilder:
+    primitive_types = (int, float, str, bool, bytes, type(None))
+
+    @staticmethod
+    def get(provider_attributes):
+        attributes = {}
+        annotations = {}
+
+        # Iterate through input_dict and split based on value types
+        for key, value in provider_attributes.items():
+            if isinstance(value, ReportDataBuilder.primitive_types):
+                attributes[key] = value
+            else:
+                annotations[key] = value
+
+        # Return both dictionaries
+        return attributes, annotations

--- a/backtracepython/attributes/user_attribute_provider.py
+++ b/backtracepython/attributes/user_attribute_provider.py
@@ -1,0 +1,10 @@
+from backtracepython.attributes.attribute_provider import AttributeProvider
+from backtracepython.version import version_string
+
+
+class UserAttributeProvider(AttributeProvider):
+    def __init__(self, attributes):
+        self.attributes = attributes
+
+    def get(self):
+        return self.attributes

--- a/backtracepython/client.py
+++ b/backtracepython/client.py
@@ -20,7 +20,13 @@ class globs:
 
 
 def get_attributes():
-    return attribute_manager.get()
+    attributes, _ = attribute_manager.get()
+    return attributes
+
+
+def get_annotations():
+    _, annotations = attribute_manager.get()
+    return annotations
 
 
 def set_attribute(key, value):

--- a/backtracepython/report.py
+++ b/backtracepython/report.py
@@ -17,8 +17,8 @@ class BacktraceReport:
         self.source_path_dict = {}
         self.attachments = []
 
-        init_attrs = {"error.type": "Exception"}
-        init_attrs.update(attribute_manager.get())
+        attributes, annotations = attribute_manager.get()
+        attributes.update({"error.type": "Exception"})
 
         self.log_lines = []
 
@@ -30,10 +30,8 @@ class BacktraceReport:
             "agent": "backtrace-python",
             "agentVersion": version_string,
             "mainThread": str(self.fault_thread.ident),
-            "attributes": init_attrs,
-            "annotations": {
-                "Environment Variables": dict(os.environ),
-            },
+            "attributes": attributes,
+            "annotations": annotations,
             "threads": self.generate_stack_trace(),
         }
 
@@ -123,6 +121,9 @@ class BacktraceReport:
 
     def set_annotation(self, key, value):
         self.report["annotations"][key] = value
+
+    def get_annotations(self):
+        return self.report["annotations"]
 
     def get_attributes(self):
         return self.report["attributes"]

--- a/tests/test_client_attributes.py
+++ b/tests/test_client_attributes.py
@@ -1,0 +1,62 @@
+from backtracepython.client import get_attributes, set_attribute, set_attributes
+from backtracepython.report import BacktraceReport
+
+
+def test_setting_client_attribute():
+    key = "foo"
+    value = "bar"
+    set_attribute(key, value)
+
+    client_attributes = get_attributes()
+    assert client_attributes[key] == value
+
+
+def test_overriding_client_attribute():
+    current_attributes = get_attributes()
+    key = list(current_attributes.keys())[0]
+    previous_value = list(current_attributes.values())[0]
+
+    new_value = "bar"
+    set_attribute(key, new_value)
+
+    client_attributes = get_attributes()
+    assert client_attributes[key] == new_value
+    assert new_value != previous_value
+
+
+def test_primitive_values_in_attributes():
+    primitive_attributes = {
+        "string": "test",
+        "int": 123,
+        "float": 123123.123,
+        "boolean": False,
+        "None": None,
+    }
+
+    set_attributes(primitive_attributes)
+    new_report = BacktraceReport()
+    report_attributes = new_report.get_attributes()
+
+    for primitive_value_key in primitive_attributes:
+        assert primitive_value_key in report_attributes
+        assert (
+            report_attributes[primitive_value_key]
+            == primitive_attributes[primitive_value_key]
+        )
+
+
+def test_complex_objects_in_annotations():
+    objects_to_test = (
+        {"foo": 1, "bar": 2},
+        ("foo", "bar", "baz"),
+        lambda: None,
+        BacktraceReport(),
+    )
+
+    for index, value in enumerate(objects_to_test):
+        set_attribute(index, value)
+
+    new_report = BacktraceReport()
+    report_annotations = new_report.get_annotations()
+
+    assert len(report_annotations) == len(objects_to_test)

--- a/tests/test_report_attributes.py
+++ b/tests/test_report_attributes.py
@@ -1,4 +1,4 @@
-from backtracepython.client import set_attribute
+from backtracepython.client import set_attribute, set_attributes
 from backtracepython.report import BacktraceReport
 
 report = BacktraceReport()
@@ -61,3 +61,27 @@ def test_override_default_client_attribute_by_report():
     new_report.set_attribute(test_attribute, test_attribute_value)
     attributes = new_report.get_attributes()
     assert attributes["guid"] == test_attribute_value
+
+
+def test_annotation_in_annotations_data():
+    annotation_name = "annotation_name"
+    annotation = {"name": "foo", "surname": "bar"}
+
+    set_attribute(annotation_name, annotation)
+
+    new_report = BacktraceReport()
+    report_annotation = new_report.get_annotations()
+    assert report_annotation[annotation_name] == annotation
+
+
+def test_override_client_annotation():
+    annotation_name = "annotation_name"
+    annotation = {"name": "foo", "surname": "bar"}
+    override_report_annotation = {"name": "foo", "surname": "bar", "age": "unknown"}
+
+    set_attribute(annotation_name, annotation)
+
+    new_report = BacktraceReport()
+    new_report.set_annotation(annotation_name, override_report_annotation)
+    report_annotation = new_report.get_annotations()
+    assert report_annotation[annotation_name] == override_report_annotation


### PR DESCRIPTION
**Why**

Our users can add advanced attributes as attributes and we should treat them from the beginning as annotations. This approach requires us to think about annotations and attributes in the attribute manager system we already have. 

This pull request checks each attribute provided by the user and converts it to the attributes/annotations in the flight 