### PR TITLE
Wait for events in the queue

### DIFF
--- a/backtracepython/client.py
+++ b/backtracepython/client.py
@@ -90,7 +90,7 @@ def initialize(
     context_line_count=200,
     collect_source_code=True,
     disable_global_handler=False,
-    exit_timeout=5,
+    exit_timeout=4,
 ):
     globs.endpoint = construct_submission_url(endpoint, token)
     globs.debug_backtrace = debug_backtrace

--- a/backtracepython/client.py
+++ b/backtracepython/client.py
@@ -116,7 +116,7 @@ def initialize(
         globs.next_except_hook = sys.excepthook
         sys.excepthook = bt_except_hook
 
-    if exit_timeout != 0:
+    if exit_timeout > 0:
         atexit.register(finalize)
 
 

--- a/backtracepython/report_queue.py
+++ b/backtracepython/report_queue.py
@@ -8,9 +8,10 @@ else:
 
 
 class ReportQueue:
-    def __init__(self, request_handler, source_code_handler=None):
+    def __init__(self, request_handler, exit_timeout=None, source_code_handler=None):
         self.request_handler = request_handler
         self.source_code_handler = source_code_handler
+        self.exit_timeout = exit_timeout
 
         # report submission tasks queue
         self.report_queue = queue.Queue()
@@ -24,7 +25,7 @@ class ReportQueue:
     def _worker(self):
         while True:
             report_data = self.report_queue.get()
-            if report_data is None or self.active == False:
+            if report_data is None:
                 self.report_queue.task_done()
                 break
             report, attachments = report_data
@@ -41,12 +42,7 @@ class ReportQueue:
             self.source_code_handler.collect(report)
         self.request_handler.send(report, attachments)
 
-    def __del__(self):
-        self.dispose()
-
-    def dispose(self):
-        # Put a sentinel value to stop the worker thread
-        self.active = False
+    def finish(self):
         self.report_queue.put_nowait(None)
         self.report_queue.join()
-        self.worker_thread.join()
+        self.worker_thread.join(timeout=self.exit_timeout)

--- a/backtracepython/report_queue.py
+++ b/backtracepython/report_queue.py
@@ -8,7 +8,7 @@ else:
 
 
 class ReportQueue:
-    def __init__(self, request_handler, exit_timeout=None, source_code_handler=None):
+    def __init__(self, request_handler, exit_timeout, source_code_handler=None):
         self.request_handler = request_handler
         self.source_code_handler = source_code_handler
         self.exit_timeout = exit_timeout
@@ -25,7 +25,7 @@ class ReportQueue:
     def _worker(self):
         while True:
             report_data = self.report_queue.get()
-            if report_data is None:
+            if report_data is None or self.active == False:
                 self.report_queue.task_done()
                 break
             report, attachments = report_data
@@ -45,5 +45,5 @@ class ReportQueue:
     def finish(self):
         # Put a sentinel value to stop the worker thread
         self.report_queue.put_nowait(None)
-        self.report_queue.join()
         self.worker_thread.join(timeout=self.exit_timeout)
+        self.active = False

--- a/backtracepython/report_queue.py
+++ b/backtracepython/report_queue.py
@@ -43,6 +43,7 @@ class ReportQueue:
         self.request_handler.send(report, attachments)
 
     def finish(self):
+        # Put a sentinel value to stop the worker thread
         self.report_queue.put_nowait(None)
         self.report_queue.join()
         self.worker_thread.join(timeout=self.exit_timeout)


### PR DESCRIPTION
# Why

Feedback from our users - in the server app it's fine to just wait a second for events to send if the application doesn't end with an unhandled exception. This change allows the setup a timeout for the queue to clean up on the application exit. Thanks to this we can see all reports from our demo, or we're using if someone is testing us with a simple script, the data is in Backtrace