### PR TITLE
Add error annotation

### DIFF
--- a/backtracepython/report.py
+++ b/backtracepython/report.py
@@ -65,11 +65,14 @@ class BacktraceReport:
         self.faulting_thread_id = fault_thread_id
         self.report["mainThread"] = self.faulting_thread_id
 
-        self.set_annotation("Exception", {
-            "type": exception_classifier,
-            "message": str(ex_value),
-            "traceback": traceback.format_tb(ex_traceback)
-        })
+        self.set_annotation(
+            "Exception",
+            {
+                "type": exception_classifier,
+                "message": str(ex_value),
+                "traceback": traceback.format_tb(ex_traceback),
+            },
+        )
 
     def capture_last_exception(self):
         self.set_exception(*sys.exc_info())

--- a/backtracepython/report.py
+++ b/backtracepython/report.py
@@ -3,6 +3,7 @@ import sys
 import threading
 import time
 import uuid
+import traceback
 
 from backtracepython.attributes.attribute_manager import attribute_manager
 
@@ -39,7 +40,8 @@ class BacktraceReport:
         }
 
     def set_exception(self, garbage, ex_value, ex_traceback):
-        self.report["classifiers"] = [ex_value.__class__.__name__]
+        exception_classifier = ex_value.__class__.__name__
+        self.report["classifiers"] = [exception_classifier]
         self.report["attributes"]["error.message"] = str(ex_value)
 
         # reset faulting thread id and make sure the faulting thread is not listed twice
@@ -62,6 +64,12 @@ class BacktraceReport:
         faulting_thread["fault"] = True
         self.faulting_thread_id = fault_thread_id
         self.report["mainThread"] = self.faulting_thread_id
+
+        self.set_annotation("Exception", {
+            "type": exception_classifier,
+            "message": str(ex_value),
+            "traceback": traceback.format_tb(ex_traceback)
+        })
 
     def capture_last_exception(self):
         self.set_exception(*sys.exc_info())

--- a/tests/test_report_attributes.py
+++ b/tests/test_report_attributes.py
@@ -85,3 +85,18 @@ def test_override_client_annotation():
     new_report.set_annotation(annotation_name, override_report_annotation)
     report_annotation = new_report.get_annotations()
     assert report_annotation[annotation_name] == override_report_annotation
+
+
+def test_set_exception_annotation():
+
+    def open_file(name):
+        open(name).read()
+
+    try:
+        open_file("not existing file")
+    except:
+        report = BacktraceReport()
+        report.capture_last_exception()
+        annotations = report.get_annotations()
+        assert annotations["Exception"] is not None
+        

--- a/tests/test_report_attributes.py
+++ b/tests/test_report_attributes.py
@@ -99,4 +99,3 @@ def test_set_exception_annotation():
         report.capture_last_exception()
         annotations = report.get_annotations()
         assert annotations["Exception"] is not None
-        


### PR DESCRIPTION
# Why

For debugging purposes and to make sure we can verify everything remotely, it's worth adding an annotation that describes a current exception object captured by us. This pull request adds by default an Exception annotation with the handled exception object.