### PR TITLE
Pop on unreadable files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.11] # List of Python versions to test against
+        python-version: [3.7, 3.8, 3.9, 3.11, 3.12, 3.13] # List of Python versions to test against
 
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.11
+          python-version: 3.13
           update-environment: false
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.4.3
+
+- Fixed invalid source code behavior when the source file doesn't exist or couldn't be read (#28)
+
 # Version 0.4.2
 
 - Fixed a bug that can mark 2+ threads as a faulting thread (#26),

--- a/backtracepython/source_code_handler.py
+++ b/backtracepython/source_code_handler.py
@@ -42,7 +42,7 @@ class SourceCodeHandler:
                 if new_max_line > source["maxLine"]:
                     source["maxLine"] = new_max_line
 
-        for source_code_path in source_code:
+        for source_code_path in list(source_code):
             source = source_code[source_code_path]
             source_code_content = self.read_source(
                 source_code_path, source["startLine"] - 1, source["maxLine"]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(current_directory, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="backtracepython",
-    version="0.4.2",
+    version="0.4.3",
     description="Backtrace.io error reporting tool for Python",
     author="Backtrace.io",
     author_email="team@backtrace.io",

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -50,7 +50,7 @@ def test_collect_keeps_readable_sources(tmp_path):
 
 
 def test_collect_mixed_readable_and_unreadable(tmp_path):
-    """Mix of existing and missing files — only readable ones should survive."""
+    """Mix of existing and missing files"""
     source_file = tmp_path / "exists.py"
     source_file.write_text("foobarbaz")
 

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -4,8 +4,7 @@ from backtracepython.source_code_handler import SourceCodeHandler
 def make_report(source_paths):
     """Build a minimal report whose main thread stack references the given file paths."""
     stack = [
-        {"sourceCode": path, "line": 10, "funcName": "test"}
-        for path in source_paths
+        {"sourceCode": path, "line": 10, "funcName": "test"} for path in source_paths
     ]
     return {
         "mainThread": "main",
@@ -22,10 +21,12 @@ def test_collect_removes_unreadable_sources_without_runtime_error():
     entries from the source_code dict while iterating over it.
     """
     handler = SourceCodeHandler(tab_width=4, context_line_count=3)
-    report = make_report([
-        "/nonexistent/path/a.py",
-        "/nonexistent/path/b.py",
-    ])
+    report = make_report(
+        [
+            "/nonexistent/path/a.py",
+            "/nonexistent/path/b.py",
+        ]
+    )
 
     # Before the fix this raised:
     #   RuntimeError: dictionary changed size during iteration
@@ -54,11 +55,13 @@ def test_collect_mixed_readable_and_unreadable(tmp_path):
     source_file.write_text("a = 1\nb = 2\n" * 10)
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=3)
-    report = make_report([
-        "/nonexistent/path/missing.py",
-        str(source_file),
-        "/another/missing/file.py",
-    ])
+    report = make_report(
+        [
+            "/nonexistent/path/missing.py",
+            str(source_file),
+            "/another/missing/file.py",
+        ]
+    )
 
     result = handler.collect(report)
 

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -38,7 +38,7 @@ def test_collect_removes_unreadable_sources_without_runtime_error():
 def test_collect_keeps_readable_sources(tmp_path):
     """Verify that readable source files are collected normally."""
     source_file = tmp_path / "real.py"
-    source_file.write_text("line1\nline2\nline3\nline4\nline5\n")
+    source_file.write_text("foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=1)
     report = make_report([str(source_file)])
@@ -52,7 +52,7 @@ def test_collect_keeps_readable_sources(tmp_path):
 def test_collect_mixed_readable_and_unreadable(tmp_path):
     """Mix of existing and missing files — only readable ones should survive."""
     source_file = tmp_path / "exists.py"
-    source_file.write_text("a = 1\nb = 2\n" * 10)
+    source_file.write_text("foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=3)
     report = make_report(

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -1,4 +1,11 @@
+import os
+
 from backtracepython.source_code_handler import SourceCodeHandler
+
+
+def write_file(path, content):
+    with open(str(path), "w") as f:
+        f.write(content)
 
 
 def make_report(source_paths):
@@ -38,7 +45,7 @@ def test_collect_removes_unreadable_sources_without_runtime_error():
 def test_collect_keeps_readable_sources(tmp_path):
     """Verify that readable source files are collected normally."""
     source_file = tmp_path / "real.py"
-    source_file.write_text(u"foobarbaz")
+    write_file(source_file, "foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=1)
     report = make_report([str(source_file)])
@@ -52,7 +59,7 @@ def test_collect_keeps_readable_sources(tmp_path):
 def test_collect_mixed_readable_and_unreadable(tmp_path):
     """Mix of existing and missing files"""
     source_file = tmp_path / "exists.py"
-    source_file.write_text(u"foobarbaz")
+    write_file(source_file, "foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=3)
     report = make_report(

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -38,7 +38,7 @@ def test_collect_removes_unreadable_sources_without_runtime_error():
 def test_collect_keeps_readable_sources(tmp_path):
     """Verify that readable source files are collected normally."""
     source_file = tmp_path / "real.py"
-    source_file.write_text("foobarbaz")
+    source_file.write_text(u"foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=1)
     report = make_report([str(source_file)])
@@ -52,7 +52,7 @@ def test_collect_keeps_readable_sources(tmp_path):
 def test_collect_mixed_readable_and_unreadable(tmp_path):
     """Mix of existing and missing files"""
     source_file = tmp_path / "exists.py"
-    source_file.write_text("foobarbaz")
+    source_file.write_text(u"foobarbaz")
 
     handler = SourceCodeHandler(tab_width=4, context_line_count=3)
     report = make_report(

--- a/tests/test_source_code_handler.py
+++ b/tests/test_source_code_handler.py
@@ -1,0 +1,67 @@
+from backtracepython.source_code_handler import SourceCodeHandler
+
+
+def make_report(source_paths):
+    """Build a minimal report whose main thread stack references the given file paths."""
+    stack = [
+        {"sourceCode": path, "line": 10, "funcName": "test"}
+        for path in source_paths
+    ]
+    return {
+        "mainThread": "main",
+        "threads": {
+            "main": {"stack": stack},
+        },
+    }
+
+
+def test_collect_removes_unreadable_sources_without_runtime_error():
+    """Reproduces RuntimeError: dictionary changed size during iteration.
+
+    When every source file in the stack is unreadable, collect() used to pop
+    entries from the source_code dict while iterating over it.
+    """
+    handler = SourceCodeHandler(tab_width=4, context_line_count=3)
+    report = make_report([
+        "/nonexistent/path/a.py",
+        "/nonexistent/path/b.py",
+    ])
+
+    # Before the fix this raised:
+    #   RuntimeError: dictionary changed size during iteration
+    result = handler.collect(report)
+
+    assert result["sourceCode"] == {}
+
+
+def test_collect_keeps_readable_sources(tmp_path):
+    """Verify that readable source files are collected normally."""
+    source_file = tmp_path / "real.py"
+    source_file.write_text("line1\nline2\nline3\nline4\nline5\n")
+
+    handler = SourceCodeHandler(tab_width=4, context_line_count=1)
+    report = make_report([str(source_file)])
+
+    result = handler.collect(report)
+
+    assert str(source_file) in result["sourceCode"]
+    assert "text" in result["sourceCode"][str(source_file)]
+
+
+def test_collect_mixed_readable_and_unreadable(tmp_path):
+    """Mix of existing and missing files — only readable ones should survive."""
+    source_file = tmp_path / "exists.py"
+    source_file.write_text("a = 1\nb = 2\n" * 10)
+
+    handler = SourceCodeHandler(tab_width=4, context_line_count=3)
+    report = make_report([
+        "/nonexistent/path/missing.py",
+        str(source_file),
+        "/another/missing/file.py",
+    ])
+
+    result = handler.collect(report)
+
+    assert str(source_file) in result["sourceCode"]
+    assert "/nonexistent/path/missing.py" not in result["sourceCode"]
+    assert "/another/missing/file.py" not in result["sourceCode"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py37, py38, py39, py310
+envlist = py27, py37, py38, py39, py310, py312, py313
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
If the file doesn't exist, we're popping from the source code collection and this action generates an error, because we're in the middle of iteration.

Error details:

```
Exception in thread Thread-1 (_worker):
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/threading.py", line 1043, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/usr/local/lib/python3.13/threading.py", line 994, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/backtracepython/report_queue.py", line 32, in _worker
    self.process(report, attachments)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/backtracepython/report_queue.py", line 42, in process
    self.source_code_handler.collect(report)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/backtracepython/source_code_handler.py", line 45, in collect
    for source_code_path in source_code:
                            ^^^^^^^^^^^
RuntimeError: dictionary changed size during iteration

```
ref: [INS-985] 

[INS-985]: https://saucedev.atlassian.net/browse/INS-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ